### PR TITLE
Maintenance updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,16 +105,18 @@ jobs:
     steps:
     - name: Download Exit Status Files
       if: always()
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: exitstatus
         path: exitstatus
+        pattern: exitstatus-*
+        merge-multiple: true
 
     - name: Delete Exit Status Artifacts
       if: always()
-      uses: geekyeggo/delete-artifact@v2
+      uses: geekyeggo/delete-artifact@v5
       with:
-        name: exitstatus
+        name: exitstatus-*
+        useGlob: true
         failOnError: false
 
     - name: Set Pipeline Exit Status

--- a/.github/workflows/deploy-package-action.yml
+++ b/.github/workflows/deploy-package-action.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Python Package Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: salt-extension-${{ inputs.version }}-packages
           path: dist

--- a/.github/workflows/docs-action.yml
+++ b/.github/workflows/docs-action.yml
@@ -45,8 +45,8 @@ jobs:
 
     - name: Upload Exit Status
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: exitstatus
+        name: exitstatus-${{ github.job }}
         path: exitstatus
         if-no-files-found: error

--- a/.github/workflows/docs-action.yml
+++ b/.github/workflows/docs-action.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Build Docs
       env:
-        SKIP_REQUIREMENTS_INSTALL: YES
+        SKIP_REQUIREMENTS_INSTALL: true
       run: |
         nox --force-color -e docs
 

--- a/.github/workflows/docs-action.yml
+++ b/.github/workflows/docs-action.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python 3.10 For Nox
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
 

--- a/.github/workflows/docs-action.yml
+++ b/.github/workflows/docs-action.yml
@@ -31,6 +31,12 @@ jobs:
       run: |
         nox --force-color -e docs
 
+    - name: Upload built docs as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-docs
+        path: docs/_build/html
+
     - name: Set Exit Status
       if: always()
       run: |

--- a/.github/workflows/get-changed-files.yml
+++ b/.github/workflows/get-changed-files.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get Changed Files
         id: changed-files
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         with:
           token: ${{ github.token }}
           list-files: escape

--- a/.github/workflows/package-action.yml
+++ b/.github/workflows/package-action.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/package-action.yml
+++ b/.github/workflows/package-action.yml
@@ -36,7 +36,7 @@ jobs:
         run: python -m build --outdir dist/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: salt-extension-${{ inputs.version }}-packages
@@ -48,3 +48,11 @@ jobs:
         run: |
           mkdir exitstatus
           echo "${{ job.status }}" > exitstatus/${{ github.job }}
+
+      - name: Upload Exit Status
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: exitstatus-${{ github.job }}
+          path: exitstatus
+          if-no-files-found: error

--- a/.github/workflows/pre-commit-action.yml
+++ b/.github/workflows/pre-commit-action.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Upload Exit Status
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: exitstatus
+          name: exitstatus-${{ github.job }}
           path: exitstatus
           if-no-files-found: error

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -29,6 +29,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 2  # coverage: Issue detecting commit SHA
 
     - name: Setup Vault
       if: ${{ inputs.setup-vault }}
@@ -55,7 +57,7 @@ jobs:
     - name: Test
       env:
         SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
-        SKIP_REQUIREMENTS_INSTALL: YES
+        SKIP_REQUIREMENTS_INSTALL: true
       run: |
         nox --force-color -e tests-3 -- -vv tests/
 
@@ -67,6 +69,7 @@ jobs:
 
     - name: Upload Project Code Coverage
       if: always()
+      continue-on-error: true
       shell: bash
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -99,6 +102,7 @@ jobs:
 
     - name: Upload Tests Code Coverage
       if: always()
+      continue-on-error: true
       shell: bash
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -167,6 +171,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -201,7 +207,7 @@ jobs:
       shell: bash
       env:
         SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
-        SKIP_REQUIREMENTS_INSTALL: YES
+        SKIP_REQUIREMENTS_INSTALL: true
       run: |
         export PATH="/C/Program Files (x86)/Windows Kits/10/bin/10.0.18362.0/x64;$PATH"
         nox --force-color -e tests-3 -- -vv tests/
@@ -214,6 +220,7 @@ jobs:
 
     - name: Upload Project Code Coverage
       if: always()
+      continue-on-error: true
       shell: bash
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -246,6 +253,7 @@ jobs:
 
     - name: Upload Tests Code Coverage
       if: always()
+      continue-on-error: true
       shell: bash
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -313,6 +321,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -333,7 +343,7 @@ jobs:
     - name: Test
       env:
         SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
-        SKIP_REQUIREMENTS_INSTALL: YES
+        SKIP_REQUIREMENTS_INSTALL: true
       run: |
         nox --force-color -e tests-3 -- -vv tests/
 
@@ -345,6 +355,7 @@ jobs:
 
     - name: Upload Project Code Coverage
       if: always()
+      continue-on-error: true
       shell: bash
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -377,6 +388,7 @@ jobs:
 
     - name: Upload Tests Code Coverage
       if: always()
+      continue-on-error: true
       shell: bash
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -18,14 +18,14 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
+          - '3.10'
         salt-version:
-          - '3005.4'
-          - '3006.4'
+          - '3006.8'
+          - '3007.0'
         include:
-          - python-version: '3.10'
-            salt-version: '3006.4'
+          - python-version: '3.8'
+            salt-version: '3006.8'
 
     steps:
     - uses: actions/checkout@v4
@@ -161,9 +161,9 @@ jobs:
       matrix:
         include:
           - python-version: '3.8'
-            salt-version: '3005.4'
+            salt-version: '3006.8'
           - python-version: '3.8'
-            salt-version: '3006.4'
+            salt-version: '3007.0'
 
     steps:
     - uses: actions/checkout@v4
@@ -307,9 +307,9 @@ jobs:
       matrix:
         include:
           - python-version: '3.9'
-            salt-version: '3005.4'
+            salt-version: '3006.8'
           - python-version: '3.10'
-            salt-version: '3006.4'
+            salt-version: '3007.0'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -34,12 +34,12 @@ jobs:
 
     - name: Setup Vault
       if: ${{ inputs.setup-vault }}
-      uses: eLco/setup-vault@v1.0.2
+      uses: eLco/setup-vault@v1.0.3
       with:
         vault_version: 1.15.4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -175,7 +175,7 @@ jobs:
         fetch-depth: 2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -325,7 +325,7 @@ jobs:
         fetch-depth: 2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -22,7 +22,7 @@ jobs:
           - '3.10'
         salt-version:
           - '3006.8'
-          - '3007.0'
+          - '3007.1'
         include:
           - python-version: '3.8'
             salt-version: '3006.8'
@@ -167,7 +167,7 @@ jobs:
           - python-version: '3.8'
             salt-version: '3006.8'
           - python-version: '3.8'
-            salt-version: '3007.0'
+            salt-version: '3007.1'
 
     steps:
     - uses: actions/checkout@v4
@@ -317,7 +317,7 @@ jobs:
           - python-version: '3.9'
             salt-version: '3006.8'
           - python-version: '3.10'
-            salt-version: '3007.0'
+            salt-version: '3007.1'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -135,7 +135,7 @@ jobs:
 
     - name: Upload Logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: runtests-${{ runner.os }}-py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}.log
         path: artifacts/runtests-*.log
@@ -148,9 +148,9 @@ jobs:
 
     - name: Upload Exit Status
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: exitstatus
+        name: exitstatus-${{ github.job }}-Py{{ matrix.python-version }}-Salt{{ matrix.salt-version }}
         path: exitstatus
         if-no-files-found: error
 
@@ -286,7 +286,7 @@ jobs:
 
     - name: Upload Logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: runtests-${{ runner.os }}-py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}.log
         path: artifacts/runtests-*.log
@@ -299,9 +299,9 @@ jobs:
 
     - name: Upload Exit Status
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: exitstatus
+        name: exitstatus-${{ github.job }}-Py{{ matrix.python-version }}-Salt{{ matrix.salt-version }}
         path: exitstatus
         if-no-files-found: error
 
@@ -421,7 +421,7 @@ jobs:
 
     - name: Upload Logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: runtests-${{ runner.os }}-py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}.log
         path: artifacts/runtests-*.log
@@ -434,8 +434,8 @@ jobs:
 
     - name: Upload Exit Status
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: exitstatus
+        name: exitstatus-${{ github.job }}-Py{{ matrix.python-version }}-Salt{{ matrix.salt-version }}
         path: exitstatus
         if-no-files-found: error


### PR DESCRIPTION
* drop `3005.4` from tests
* `3006.4` -> `3006.8`
* add `3007.1` to tests
* fix coverage commit SHA detection
* don't fail when coverage upload timeouts (the actual connection, not when uploads are throttled, this has worked before) https://github.com/salt-extensions/saltext-pushover/actions/runs/8866623452/job/24346766979
* upload built docs as an artifact for later reuse, if desired
* ensure the package action uploads its exit status
* migrate from `actions/(upload|download)-artifact@v3` to `@v4` (v3 is deprecated and will error beginning in November)
* upgrade `dorny/paths-filter` from v2 to v3
* upgrade `actions/setup-python` from v4 to v5 (solves Node.js 16 warnings)
* upgrade `eLco/setup-vault` from v1.0.2 to v1.0.3 (solves Node.js 16 warnings)

Side note: I don't think the org has a codecov token, this might be something to consider. It would also be nice to see coverage in PRs (maybe by switching to `actions/codecov` or at least also generating an HTML report that can be downloaded as an artifact). In the current state, I don't think we're using the coverage information for anything.