### PR TITLE
Make tests timeout configurable, increase default for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: boolean
         default: false
+      tests-timeout:
+        required: false
+        type: number
+        default: 40
       version:
         required: false
         type: string
@@ -51,6 +55,7 @@ jobs:
     uses: salt-extensions/central-artifacts/.github/workflows/test-action.yml@main
     with:
       setup-vault: ${{ inputs.setup-vault }}
+      tests-timeout: ${{ inputs.tests-timeout }}
 
   docs:
     name: Docs

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -7,11 +7,15 @@ on:
         required: false
         type: boolean
         default: false
+      tests-timeout:
+        required: false
+        type: number
+        default: 40
 
 jobs:
   Linux:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.tests-timeout }}
 
     strategy:
       fail-fast: false
@@ -157,7 +161,7 @@ jobs:
 
   Windows:
     runs-on: windows-latest
-    timeout-minutes: 40
+    timeout-minutes: ${{ inputs.tests-timeout }}
 
     strategy:
       fail-fast: false
@@ -307,7 +311,7 @@ jobs:
 
   macOS:
     runs-on: macOS-latest
-    timeout-minutes: 40
+    timeout-minutes: ${{ inputs.tests-timeout }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
* The test suite extensiveness varies heavily per saltext. This change makes the timeout configurable. 
* Effectively increases the default for Linux tests from 30 to 40 minutes.

Context: `saltext-vault` currently takes near the maximum of 30 minutes on Linux boxes and is canceled sometimes.
