### PR TITLE
Optionally upload docs to GH Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   workflow_call:
     inputs:
+      deploy-docs:
+        required: false
+        type: boolean
+        default: false
       setup-vault:
         required: false
         type: boolean
@@ -62,6 +66,19 @@ jobs:
     needs:
       - pre-commit
     uses: salt-extensions/central-artifacts/.github/workflows/docs-action.yml@main
+
+  deploy-docs:
+    name: Deploy Docs
+    uses: salt-extensions/central-artifacts/.github/workflows/deploy-docs-action.yml@main
+    # Only build doc deployments from the main branch of the org repo and never for PRs.
+    if: >
+      ${{ inputs.deploy-docs &&
+          github.repository_owner == 'salt-extensions' &&
+          github.ref == 'refs/heads/main' &&
+          github.event_name != 'pull_request'
+      }}
+    needs:
+      - docs
 
   build-python-package:
     name: Python Package

--- a/.github/workflows/deploy-docs-action.yml
+++ b/.github/workflows/deploy-docs-action.yml
@@ -1,0 +1,62 @@
+name: Publish Documentation
+
+on:
+  workflow_call:
+    inputs:
+      # This is the name of the regular artifact that should
+      # be transformed into a GitHub Pages deployment.
+      artifact-name:
+        type: string
+        required: false
+        default: html-docs
+
+jobs:
+
+  # The released docs are not versioned currently, only the latest ones are deployed.
+  #
+  # Versioning support would require either (better):
+  #   * Rebuilding docs for all versions when a new release is made
+  #   * Version selector support in `furo`: https://github.com/pradyunsg/furo/pull/500
+  #
+  # or (more basic):
+  #   * using the `gh-pages` branch and peaceiris/actions-gh-pages
+  #     to be able to deploy to subdirectories. The implementation via
+  #     actions/deploy-pages always replaces the directory root.
+
+  Deploy-Docs-GH-Pages:
+    name: Publish Docs to GitHub Pages
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    permissions:
+      pages: write
+      id-token: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download built docs
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: html-docs
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: html-docs-pages
+          path: html-docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: html-docs-pages
+
+      - name: Delete GitHub Pages artifact
+        if: always()
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: html-docs-pages
+          failOnError: false


### PR DESCRIPTION
Adds a switch for automatically deploying the latest built docs to GitHub Pages.

This approach is very basic (not versioned), but helps solve the immediate problem of not having any docs on most published extensions.

When using GH Pages instead of readthedocs, versioning support would require either (better):
  * Rebuilding docs for all versions when a new release is made
  * Version selector support in `furo`: https://github.com/pradyunsg/furo/pull/500
  
or (more basic):
  * using the `gh-pages` branch and peaceiris/actions-gh-pages
    to be able to deploy to subdirectories. The implementation via
    actions/deploy-pages always replaces the directory root.