### PR TITLE
Fix and relax the conditional on docs deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,13 +70,11 @@ jobs:
   deploy-docs:
     name: Deploy Docs
     uses: salt-extensions/central-artifacts/.github/workflows/deploy-docs-action.yml@main
-    # Only build doc deployments from the main branch of the org repo and never for PRs.
-    if: >
-      ${{ inputs.deploy-docs &&
-          github.repository_owner == 'salt-extensions' &&
-          github.ref == 'refs/heads/main' &&
-          github.event_name != 'pull_request'
-      }}
+    # Only build doc deployments from the default branch of the repo and never for PRs.
+    if: >-
+      github.event_name != 'pull_request' &&
+      inputs.deploy-docs &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     needs:
       - docs
       - test


### PR DESCRIPTION
Not all was fine after all, the multiline conditional always evaluated to true because of the final newline not being stripped.

This should work now and also allows being called from outside the org and when the default branch is not called `main`.