### PR TITLE
Improve/udpate pre-commit hooks, fix run order, homogenize YAML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 name: CI
 
 on:
@@ -124,28 +125,28 @@ jobs:
       - deploy-python-package-test-pypi
       - deploy-python-package
     steps:
-    - name: Download Exit Status Files
-      if: always()
-      uses: actions/download-artifact@v4
-      with:
-        path: exitstatus
-        pattern: exitstatus-*
-        merge-multiple: true
+      - name: Download Exit Status Files
+        if: always()
+        uses: actions/download-artifact@v4
+        with:
+          path: exitstatus
+          pattern: exitstatus-*
+          merge-multiple: true
 
-    - name: Delete Exit Status Artifacts
-      if: always()
-      uses: geekyeggo/delete-artifact@v5
-      with:
-        name: exitstatus-*
-        useGlob: true
-        failOnError: false
+      - name: Delete Exit Status Artifacts
+        if: always()
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: exitstatus-*
+          useGlob: true
+          failOnError: false
 
-    - name: Set Pipeline Exit Status
-      run: |
-        tree exitstatus
-        grep -RE 'failure|cancelled' exitstatus/ && exit 1 || exit 0
+      - name: Set Pipeline Exit Status
+        run: |
+          tree exitstatus
+          grep -RE 'failure|cancelled' exitstatus/ && exit 1 || exit 0
 
-    - name: Done
-      if: always()
-      run:
-        echo "All workflows finished"
+      - name: Done
+        if: always()
+        run:
+          echo "All workflows finished"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
     needs:
       - test
       - docs
+      - deploy-docs
       - build-python-package
       - deploy-python-package-test-pypi
       - deploy-python-package

--- a/.github/workflows/deploy-docs-action.yml
+++ b/.github/workflows/deploy-docs-action.yml
@@ -1,3 +1,4 @@
+---
 name: Publish Documentation
 
 on:

--- a/.github/workflows/deploy-package-action.yml
+++ b/.github/workflows/deploy-package-action.yml
@@ -1,3 +1,4 @@
+---
 name: Deploy Salt Extension Python Package
 
 on:

--- a/.github/workflows/docs-action.yml
+++ b/.github/workflows/docs-action.yml
@@ -1,3 +1,4 @@
+---
 name: Build Documentation
 
 on:
@@ -9,44 +10,44 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python 3.10 For Nox
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
+      - name: Set up Python 3.10 For Nox
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
 
-    - name: Install Nox
-      run: |
-        python -m pip install --upgrade pip
-        pip install nox
+      - name: Install Nox
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox
 
-    - name: Install Doc Requirements
-      run: |
-        nox --force-color -e docs --install-only
+      - name: Install Doc Requirements
+        run: |
+          nox --force-color -e docs --install-only
 
-    - name: Build Docs
-      env:
-        SKIP_REQUIREMENTS_INSTALL: true
-      run: |
-        nox --force-color -e docs
+      - name: Build Docs
+        env:
+          SKIP_REQUIREMENTS_INSTALL: true
+        run: |
+          nox --force-color -e docs
 
-    - name: Upload built docs as artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: html-docs
-        path: docs/_build/html
+      - name: Upload built docs as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-docs
+          path: docs/_build/html
 
-    - name: Set Exit Status
-      if: always()
-      run: |
-        mkdir exitstatus
-        echo "${{ job.status }}" > exitstatus/${{ github.job }}
+      - name: Set Exit Status
+        if: always()
+        run: |
+          mkdir exitstatus
+          echo "${{ job.status }}" > exitstatus/${{ github.job }}
 
-    - name: Upload Exit Status
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: exitstatus-${{ github.job }}
-        path: exitstatus
-        if-no-files-found: error
+      - name: Upload Exit Status
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: exitstatus-${{ github.job }}
+          path: exitstatus
+          if-no-files-found: error

--- a/.github/workflows/get-changed-files.yml
+++ b/.github/workflows/get-changed-files.yml
@@ -1,3 +1,4 @@
+---
 on:
   workflow_call:
     outputs:

--- a/.github/workflows/package-action.yml
+++ b/.github/workflows/package-action.yml
@@ -1,3 +1,4 @@
+---
 name: Salt Extension Python Package
 
 on:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,3 +1,4 @@
+---
 name: Pull Request or Push
 
 on:

--- a/.github/workflows/pre-commit-action.yml
+++ b/.github/workflows/pre-commit-action.yml
@@ -1,3 +1,4 @@
+---
 name: Pre-Commit
 
 on:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,3 +1,4 @@
+---
 name: Testing
 
 on:
@@ -32,131 +33,131 @@ jobs:
             salt-version: '3006.8'
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 2  # coverage: Issue detecting commit SHA
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # coverage: Issue detecting commit SHA
 
-    - name: Setup Vault
-      if: ${{ inputs.setup-vault }}
-      uses: eLco/setup-vault@v1.0.3
-      with:
-        vault_version: 1.15.4
+      - name: Setup Vault
+        if: ${{ inputs.setup-vault }}
+        uses: eLco/setup-vault@v1.0.3
+        with:
+          vault_version: 1.15.4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install Nox
-      run: |
-        python -m pip install --upgrade pip
-        pip install nox
+      - name: Install Nox
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox
 
-    - name: Install Test Requirements
-      env:
-        SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
-      run: |
-        nox --force-color -e tests-3 --install-only
+      - name: Install Test Requirements
+        env:
+          SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
+        run: |
+          nox --force-color -e tests-3 --install-only
 
-    - name: Test
-      env:
-        SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
-        SKIP_REQUIREMENTS_INSTALL: true
-      run: |
-        nox --force-color -e tests-3 -- -vv tests/
+      - name: Test
+        env:
+          SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
+          SKIP_REQUIREMENTS_INSTALL: true
+        run: |
+          nox --force-color -e tests-3 -- -vv tests/
 
-    - name: Create CodeCov Flags
-      if: always()
-      id: codecov-flags
-      run: |
-        echo "flags=$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))")" >> "$GITHUB_OUTPUT"
+      - name: Create CodeCov Flags
+        if: always()
+        id: codecov-flags
+        run: |
+          echo "flags=$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))")" >> "$GITHUB_OUTPUT"
 
-    - name: Upload Project Code Coverage
-      if: always()
-      continue-on-error: true
-      shell: bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},project
-        REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-project
-        REPORT_PATH: artifacts/coverage-project.xml
-      run: |
-        if [ ! -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-          if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
-              break
-          fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
-        if [ -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+      - name: Upload Project Code Coverage
+        if: always()
+        continue-on-error: true
+        shell: bash
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},project
+          REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-project
+          REPORT_PATH: artifacts/coverage-project.xml
+        run: |
+          if [ ! -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+            if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
                 break
             fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
-
-    - name: Upload Tests Code Coverage
-      if: always()
-      continue-on-error: true
-      shell: bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},tests
-        REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-tests
-        REPORT_PATH: artifacts/coverage-tests.xml
-      run: |
-        if [ ! -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-          if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
-              break
+              n=$((n+1))
+              sleep 15
+            done
           fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
-        if [ -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+          if [ -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+              if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+                  break
+              fi
+              n=$((n+1))
+              sleep 15
+            done
+          fi
+
+      - name: Upload Tests Code Coverage
+        if: always()
+        continue-on-error: true
+        shell: bash
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},tests
+          REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-tests
+          REPORT_PATH: artifacts/coverage-tests.xml
+        run: |
+          if [ ! -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+            if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
                 break
             fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
+              n=$((n+1))
+              sleep 15
+            done
+          fi
+          if [ -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+              if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+                  break
+              fi
+              n=$((n+1))
+              sleep 15
+            done
+          fi
 
-    - name: Upload Logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: runtests-${{ runner.os }}-py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}.log
-        path: artifacts/runtests-*.log
+      - name: Upload Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtests-${{ runner.os }}-py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}.log
+          path: artifacts/runtests-*.log
 
-    - name: Set Exit Status
-      if: always()
-      run: |
-        mkdir exitstatus
-        echo "${{ job.status }}" > exitstatus/${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
+      - name: Set Exit Status
+        if: always()
+        run: |
+          mkdir exitstatus
+          echo "${{ job.status }}" > exitstatus/${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
 
-    - name: Upload Exit Status
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: exitstatus-${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
-        path: exitstatus
-        if-no-files-found: error
+      - name: Upload Exit Status
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: exitstatus-${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
+          path: exitstatus
+          if-no-files-found: error
 
 
   Windows:
@@ -174,142 +175,142 @@ jobs:
             salt-version: '3007.1'
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Download libeay32.dll
-      run: |
-        PY_LOC="$(which python.exe)"
-        export PY_LOC
-        echo "${PY_LOC}"
-        PY_DIR="$(dirname "${PY_LOC}")"
-        export PY_DIR
-        echo "${PY_DIR}"
-        curl https://repo.saltproject.io/windows/dependencies/64/libeay32.dll --output "${PY_DIR}/libeay32.dll"
-        ls -l "${PY_DIR}"
-      shell: bash
+      - name: Download libeay32.dll
+        run: |
+          PY_LOC="$(which python.exe)"
+          export PY_LOC
+          echo "${PY_LOC}"
+          PY_DIR="$(dirname "${PY_LOC}")"
+          export PY_DIR
+          echo "${PY_DIR}"
+          curl https://repo.saltproject.io/windows/dependencies/64/libeay32.dll --output "${PY_DIR}/libeay32.dll"
+          ls -l "${PY_DIR}"
+        shell: bash
 
-    - name: Install Nox
-      run: |
-        python -m pip install --upgrade pip
-        pip install nox
+      - name: Install Nox
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox
 
-    - name: Install Test Requirements
-      shell: bash
-      env:
-        SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
-        # EXTRA_REQUIREMENTS_INSTALL: Cython
-      run: |
-        export PATH="/C/Program Files (x86)/Windows Kits/10/bin/10.0.18362.0/x64;$PATH"
-        nox --force-color -e tests-3 --install-only
+      - name: Install Test Requirements
+        shell: bash
+        env:
+          SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
+          # EXTRA_REQUIREMENTS_INSTALL: Cython
+        run: |
+          export PATH="/C/Program Files (x86)/Windows Kits/10/bin/10.0.18362.0/x64;$PATH"
+          nox --force-color -e tests-3 --install-only
 
-    - name: Test
-      shell: bash
-      env:
-        SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
-        SKIP_REQUIREMENTS_INSTALL: true
-      run: |
-        export PATH="/C/Program Files (x86)/Windows Kits/10/bin/10.0.18362.0/x64;$PATH"
-        nox --force-color -e tests-3 -- -vv tests/
+      - name: Test
+        shell: bash
+        env:
+          SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
+          SKIP_REQUIREMENTS_INSTALL: true
+        run: |
+          export PATH="/C/Program Files (x86)/Windows Kits/10/bin/10.0.18362.0/x64;$PATH"
+          nox --force-color -e tests-3 -- -vv tests/
 
-    - name: Create CodeCov Flags
-      if: always()
-      id: codecov-flags
-      run: |
-        echo "flags=$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))")" >> "$GITHUB_OUTPUT"
+      - name: Create CodeCov Flags
+        if: always()
+        id: codecov-flags
+        run: |
+          echo "flags=$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))")" >> "$GITHUB_OUTPUT"
 
-    - name: Upload Project Code Coverage
-      if: always()
-      continue-on-error: true
-      shell: bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},project
-        REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-project
-        REPORT_PATH: artifacts/coverage-project.xml
-      run: |
-        if [ ! -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-          if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
-              break
-          fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
-        if [ -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+      - name: Upload Project Code Coverage
+        if: always()
+        continue-on-error: true
+        shell: bash
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},project
+          REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-project
+          REPORT_PATH: artifacts/coverage-project.xml
+        run: |
+          if [ ! -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+            if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
                 break
             fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
-
-    - name: Upload Tests Code Coverage
-      if: always()
-      continue-on-error: true
-      shell: bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},tests
-        REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-tests
-        REPORT_PATH: artifacts/coverage-tests.xml
-      run: |
-        if [ ! -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-          if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
-              break
+              n=$((n+1))
+              sleep 15
+            done
           fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
-        if [ -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+          if [ -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+              if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+                  break
+              fi
+              n=$((n+1))
+              sleep 15
+            done
+          fi
+
+      - name: Upload Tests Code Coverage
+        if: always()
+        continue-on-error: true
+        shell: bash
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},tests
+          REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-tests
+          REPORT_PATH: artifacts/coverage-tests.xml
+        run: |
+          if [ ! -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+            if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
                 break
             fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
+              n=$((n+1))
+              sleep 15
+            done
+          fi
+          if [ -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+              if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+                  break
+              fi
+              n=$((n+1))
+              sleep 15
+            done
+          fi
 
-    - name: Upload Logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: runtests-${{ runner.os }}-py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}.log
-        path: artifacts/runtests-*.log
+      - name: Upload Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtests-${{ runner.os }}-py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}.log
+          path: artifacts/runtests-*.log
 
-    - name: Set Exit Status
-      if: always()
-      run: |
-        mkdir exitstatus
-        echo "${{ job.status }}" > exitstatus/${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
+      - name: Set Exit Status
+        if: always()
+        run: |
+          mkdir exitstatus
+          echo "${{ job.status }}" > exitstatus/${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
 
-    - name: Upload Exit Status
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: exitstatus-${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
-        path: exitstatus
-        if-no-files-found: error
+      - name: Upload Exit Status
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: exitstatus-${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
+          path: exitstatus
+          if-no-files-found: error
 
   macOS:
     runs-on: macOS-latest
@@ -326,122 +327,122 @@ jobs:
             salt-version: '3007.1'
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install Nox
-      run: |
-        python -m pip install --upgrade pip
-        pip install nox
+      - name: Install Nox
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox
 
-    - name: Install Test Requirements
-      env:
-        SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
-      run: |
-        nox --force-color -e tests-3 --install-only
+      - name: Install Test Requirements
+        env:
+          SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
+        run: |
+          nox --force-color -e tests-3 --install-only
 
-    - name: Test
-      env:
-        SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
-        SKIP_REQUIREMENTS_INSTALL: true
-      run: |
-        nox --force-color -e tests-3 -- -vv tests/
+      - name: Test
+        env:
+          SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
+          SKIP_REQUIREMENTS_INSTALL: true
+        run: |
+          nox --force-color -e tests-3 -- -vv tests/
 
-    - name: Create CodeCov Flags
-      if: always()
-      id: codecov-flags
-      run: |
-        echo "flags=$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))")" >> "$GITHUB_OUTPUT"
+      - name: Create CodeCov Flags
+        if: always()
+        id: codecov-flags
+        run: |
+          echo "flags=$(python -c "import sys; print('{},{},salt_{}'.format('${{ runner.os }}'.replace('-latest', ''), 'py{}{}'.format(*sys.version_info), '_'.join(str(v) for v in '${{ matrix.salt-version }}'.replace('==', '_').split('.'))))")" >> "$GITHUB_OUTPUT"
 
-    - name: Upload Project Code Coverage
-      if: always()
-      continue-on-error: true
-      shell: bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},project
-        REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-project
-        REPORT_PATH: artifacts/coverage-project.xml
-      run: |
-        if [ ! -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-          if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
-              break
-          fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
-        if [ -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+      - name: Upload Project Code Coverage
+        if: always()
+        continue-on-error: true
+        shell: bash
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},project
+          REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-project
+          REPORT_PATH: artifacts/coverage-project.xml
+        run: |
+          if [ ! -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+            if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
                 break
             fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
-
-    - name: Upload Tests Code Coverage
-      if: always()
-      continue-on-error: true
-      shell: bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},tests
-        REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-tests
-        REPORT_PATH: artifacts/coverage-tests.xml
-      run: |
-        if [ ! -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-          if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
-              break
+              n=$((n+1))
+              sleep 15
+            done
           fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
-        if [ -f codecov.sh ]; then
-          n=0
-          until [ "$n" -ge 5 ]
-          do
-            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+          if [ -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+              if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+                  break
+              fi
+              n=$((n+1))
+              sleep 15
+            done
+          fi
+
+      - name: Upload Tests Code Coverage
+        if: always()
+        continue-on-error: true
+        shell: bash
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          REPORT_FLAGS: ${{ steps.codecov-flags.outputs.flags }},tests
+          REPORT_NAME: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-tests
+          REPORT_PATH: artifacts/coverage-tests.xml
+        run: |
+          if [ ! -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+            if curl --max-time 30 -L https://codecov.io/bash --output codecov.sh; then
                 break
             fi
-            n=$((n+1))
-            sleep 15
-          done
-        fi
+              n=$((n+1))
+              sleep 15
+            done
+          fi
+          if [ -f codecov.sh ]; then
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+              if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+                  break
+              fi
+              n=$((n+1))
+              sleep 15
+            done
+          fi
 
-    - name: Upload Logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: runtests-${{ runner.os }}-py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}.log
-        path: artifacts/runtests-*.log
+      - name: Upload Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtests-${{ runner.os }}-py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}.log
+          path: artifacts/runtests-*.log
 
-    - name: Set Exit Status
-      if: always()
-      run: |
-        mkdir exitstatus
-        echo "${{ job.status }}" > exitstatus/${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
+      - name: Set Exit Status
+        if: always()
+        run: |
+          mkdir exitstatus
+          echo "${{ job.status }}" > exitstatus/${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
 
-    - name: Upload Exit Status
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: exitstatus-${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
-        path: exitstatus
-        if-no-files-found: error
+      - name: Upload Exit Status
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: exitstatus-${{ github.job }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}
+          path: exitstatus
+          if-no-files-found: error

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -96,7 +96,7 @@ jobs:
           n=0
           until [ "$n" -ge 5 ]
           do
-            if bash codecov.sh -R $(pwd) -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
                 break
             fi
             n=$((n+1))
@@ -129,7 +129,7 @@ jobs:
           n=0
           until [ "$n" -ge 5 ]
           do
-            if bash codecov.sh -R $(pwd) -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
                 break
             fi
             n=$((n+1))
@@ -185,12 +185,14 @@ jobs:
 
     - name: Download libeay32.dll
       run: |
-        export PY_LOC=$(which python.exe)
-        echo ${PY_LOC}
-        export PY_DIR=$(dirname ${PY_LOC})
-        echo ${PY_DIR}
-        curl https://repo.saltproject.io/windows/dependencies/64/libeay32.dll --output ${PY_DIR}/libeay32.dll
-        ls -l ${PY_DIR}
+        PY_LOC="$(which python.exe)"
+        export PY_LOC
+        echo "${PY_LOC}"
+        PY_DIR="$(dirname "${PY_LOC}")"
+        export PY_DIR
+        echo "${PY_DIR}"
+        curl https://repo.saltproject.io/windows/dependencies/64/libeay32.dll --output "${PY_DIR}/libeay32.dll"
+        ls -l "${PY_DIR}"
       shell: bash
 
     - name: Install Nox
@@ -247,7 +249,7 @@ jobs:
           n=0
           until [ "$n" -ge 5 ]
           do
-            if bash codecov.sh -R $(pwd) -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
                 break
             fi
             n=$((n+1))
@@ -280,7 +282,7 @@ jobs:
           n=0
           until [ "$n" -ge 5 ]
           do
-            if bash codecov.sh -R $(pwd) -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
                 break
             fi
             n=$((n+1))
@@ -382,7 +384,7 @@ jobs:
           n=0
           until [ "$n" -ge 5 ]
           do
-            if bash codecov.sh -R $(pwd) -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
                 break
             fi
             n=$((n+1))
@@ -415,7 +417,7 @@ jobs:
           n=0
           until [ "$n" -ge 5 ]
           do
-            if bash codecov.sh -R $(pwd) -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
+            if bash codecov.sh -R "$(pwd)" -n "${REPORT_NAME}" -f "${REPORT_PATH}" -F "${REPORT_FLAGS}"; then
                 break
             fi
             n=$((n+1))

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,10 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
         args: ["--allow-multiple-documents"]
+
+  - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
+    rev: v1.7.1.15
+    hooks:
+      - id: actionlint
+        additional_dependencies:
+          - shellcheck-py>=0.9.0.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 minimum_pre_commit_version: 2.4.0
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: trailing-whitespace


### PR DESCRIPTION
* Adds `actionlint` with `shellcheck` integration as pre-commit hook and fixes issues. This should help dodge some unexpected bullets before merging patches
* Makes `set-pipeline-exit-status` always run after `deploy-docs`
* Adds YAML doc beginning `---` and indents lists the same way to make yamllint happier