### PR TITLE
Add scheduled RenovateBot workflow for Copier

### DIFF
--- a/.github/renovate-global.json
+++ b/.github/renovate-global.json
@@ -1,0 +1,23 @@
+{
+    "extends":
+    [
+        "customManagers:githubActionsVersions"
+    ],
+    "platform": "github",
+    "onboarding": false,
+    "requireConfig": "ignored",
+    "enabledManagers":
+    [
+        "copier",
+        "custom.regex"
+    ],
+    "allowScripts": true,
+    "ignoreScripts": false,
+    "autodiscover": true,
+    "platformCommit": true,
+    "constraints":
+    {
+        "copier": ">=9.3",
+        "python": "3.10"
+    }
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,44 @@
+---
+name: Update Copier template
+
+on:
+  workflow_dispatch:
+    inputs:
+      repoFilter:
+        description: >
+          Filter the repositories Renovate runs against.
+          Can be regex or minimatch glob-style.
+          See https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter
+        required: false
+        default: 'salt-extensions/*'
+        type: string
+  schedule:
+    - cron: '23 4 * * *'
+
+env:
+  # renovate: datasource=docker depName=renovate packageName=ghcr.io/renovatebot/renovate
+  RENOVATE_VERSION: 38.94.2
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GHA_RENOVATE_APP_ID }}
+          private-key: ${{ secrets.GHA_RENOVATE_PK }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v4.1.7
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v40.2.10
+        with:
+          configurationFile: .github/renovate-global.json
+          renovate-version: ${{ env.RENOVATE_VERSION }}
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          RENOVATE_AUTODISCOVER_FILTER: ${{ github.event_name == 'workflow_dispatch' && inputs.repoFilter || 'salt-extensions/*' }}


### PR DESCRIPTION
Adds basic RenovateBot configuration and a scheduled workflow that runs daily against all repositories in the `salt-extensions` organization, initially for updating the Copier template version only. We might use it for updating versions in workflows and the template repository itself in the future.

This was made possible by writing the Copier manager and the 0.4.0 salt-extension-copier release, which works around an annoying bug regarding unwanted boilerplate regeneration.

Will probably need to be adjusted/fixed, but we need to start somewhere. I hope this doesn't cause too much noise, will need to monitor.