### PR TITLE
Run pre-commit against all files if PR changes lint config

### DIFF
--- a/.github/workflows/get-changed-files.yml
+++ b/.github/workflows/get-changed-files.yml
@@ -31,6 +31,11 @@ jobs:
             deleted:
               - deleted:
                 - '**'
-
+            pre-commit:
+              - added|modified|deleted:
+                - .pre-commit-hooks/**
+                - .pre-commit-config.y?(a)ml
+                - .pylintrc
+                - pyproject.toml
       - name: Echo Changed Files Output
         run: echo "${{ toJSON(steps.changed-files.outputs) }}"

--- a/.github/workflows/pre-commit-action.yml
+++ b/.github/workflows/pre-commit-action.yml
@@ -32,7 +32,7 @@ jobs:
           pre-commit install --install-hooks
 
       - name: Check ALL Files On Branch
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || fromJSON(inputs.changed-files)['pre-commit'] == 'true'
         run: |
           pre-commit run --show-diff-on-failure --color=always --all-files
 


### PR DESCRIPTION
This (automated) PR changed Pylint config: https://github.com/salt-extensions/saltext-pushover/pull/26
It passed CI: https://github.com/salt-extensions/saltext-pushover/actions/runs/11013025780

Merging it revealed Pylint issues: https://github.com/salt-extensions/saltext-pushover/actions/runs/11013121801

We should do a full pre-commit run if specific files relevant for pre-commit change:

* anything in .pre-commit-hooks dir
* .pre-commit-config
* .pylintrc
* pyproject.toml (contains `black`/`isort` config, e.g.)