### PR TITLE
Update Renovate config

### DIFF
--- a/.github/renovate-global.json
+++ b/.github/renovate-global.json
@@ -31,6 +31,15 @@
                 "/https:\\/\\/github.com\\/(salt-extensions|lkubb)\\/salt-extension-copier/"
             ],
             "enabled": true
+        },
+        {
+            "matchPackageNames": ["renovate"],
+            "schedule": ["before 7am on Monday"]
+        },
+        {
+            "matchPackageNames": ["renovate"],
+            "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+            "automerge": true
         }
     ]
 }

--- a/.github/renovate-global.json
+++ b/.github/renovate-global.json
@@ -19,5 +19,18 @@
     {
         "copier": ">=9.3",
         "python": "3.10.15"
-    }
+    },
+    "packageRules": [
+        {
+            "matchManagers": ["copier"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["copier"],
+            "matchPackageNames": [
+                "/https:\\/\\/github.com\\/(salt-extensions|lkubb)\\/salt-extension-copier/"
+            ],
+            "enabled": true
+        }
+    ]
 }


### PR DESCRIPTION
### Ensure only trusted Copier templates are managed
Since we allow running arbitrary scripts in the container, executing custom Copier template updates would allow anyone with write access to a single repository inside the organization to run arbitrary code, potentially allowing privilege escalation within the org.

This patch disables updates for any Copier templates, with the exception of the two trusted sources for the template.

We should migrate all extensions to use the `salt-extensions` source, allowing to restrict this even further.

The order of the packageRules is important, since the last matching one overrides configuration from previous ones.

Note that this is also the reason why repository configuration is ignored.

### Others
* Reduce Renovate self-update frequency to once a week
* Automerge self-updates